### PR TITLE
global: reduce crates.io keywords

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,14 +4,10 @@ version = "0.4.0"
 authors = ["Marco Neumann <marco@crepererum.net>"]
 license = "MIT/Apache-2.0"
 keywords = [
-    "bloomfilter",
-    "countminsketch",
-    "cuckoofilter",
     "filter",
-    "hyperloglog",
-    "reservoirsampling",
+    "probabilistic",
+    "sampling",
     "sketch",
-    "topk",
 ]
 categories = ["data-structures"]
 description = "Simple probabilistic data structures"


### PR DESCRIPTION
It seems you can have at max 5 keywords.