### PR TITLE
Fixed array out of bounds bug in HyperLogLog.

### DIFF
--- a/src/hyperloglog.rs
+++ b/src/hyperloglog.rs
@@ -182,7 +182,7 @@ where
                     // no right index
                     (Some(i - 1), None)
                 } else {
-                    (Some(i), Some(i + 1))
+                    (Some(i - 1), Some(i))
                 }
             }
         }
@@ -675,7 +675,7 @@ mod tests {
 
         assert_eq!(
             HyperLogLog::<u32>::neighbor_search_startpoints(lookup_array, 20.),
-            (Some(15), Some(16))
+            (Some(14), Some(15))
         );
 
         assert_eq!(


### PR DESCRIPTION
### Issue
When using HyperLogLog on a large dataset, I came across a panic due to array out of bounds indexing in the neighbor mean calculation in `estimate_bias`. This was on the most recent master branch, and not the 0.6.0 version of pdatastructs which I know has a separate index out of bounds bug.

### Explanation and solution
The issue occurs due to [this](https://github.com/crepererum/pdatastructs.rs/blob/master/src/hyperloglog.rs#L185) line in `neighbor_search_startpoints`, in particular the case where `binary_search_by` returns `Err(n-1)` for `n = lookup_array.len()`. When no exact match is found, binary searching by `key` returns the index `i` of the smallest element that is strictly greater than `key`, which means that the neighbor startpoints should be `(i-1, i)` and not `(i, i+1)`. As an example, consider `lookup_array = vec![0, 2, 4]` and `key = 1`. Clearly we would want to return startpoints `(0, 1)`, which corresponds to `(i-1, i)` if `i` is the return value of our binary search, and not `(i, i+1)` as the code does now.
