### PR TITLE
filter: allow unsized types in filters

### DIFF
--- a/src/filters/bloomfilter.rs
+++ b/src/filters/bloomfilter.rs
@@ -141,7 +141,7 @@ use crate::hash_utils::HashIterBuilder;
 /// - ["Space/Time Trade-offs in Hash Coding with Allowable Errors", Burton H. Bloom, 1970](http://dmod.eu/deca/ft_gateway.cfm.pdf)
 /// - [Wikipedia: Bloom filter](https://en.wikipedia.org/wiki/Bloom_filter)
 #[derive(Clone)]
-pub struct BloomFilter<T, B = BuildHasherDefault<DefaultHasher>>
+pub struct BloomFilter<T: ?Sized, B = BuildHasherDefault<DefaultHasher>>
 where
     T: Hash,
     B: BuildHasher + Clone + Eq,
@@ -154,7 +154,7 @@ where
 
 impl<T> BloomFilter<T>
 where
-    T: Hash,
+    T: Hash + ?Sized,
 {
     /// Create new, empty BloomFilter with internal parameters.
     ///
@@ -180,7 +180,7 @@ where
 
 impl<T, B> BloomFilter<T, B>
 where
-    T: Hash,
+    T: Hash + ?Sized,
     B: BuildHasher + Clone + Eq,
 {
     /// Same as `with_params` but with specific `BuildHasher`.
@@ -227,7 +227,7 @@ where
 
 impl<T, B> Filter<T> for BloomFilter<T, B>
 where
-    T: Hash,
+    T: Hash + ?Sized,
     B: BuildHasher + Clone + Eq,
 {
     type InsertErr = Infallible;
@@ -302,7 +302,7 @@ where
 
 impl<T> fmt::Debug for BloomFilter<T>
 where
-    T: Hash,
+    T: Hash + ?Sized,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "BloomFilter {{ m: {}, k: {} }}", self.bs.len(), self.k)
@@ -498,5 +498,14 @@ mod tests {
         assert!(bf.query(&1));
         assert!(bf.query(&2));
         assert!(!bf.query(&3));
+    }
+
+    #[test]
+    fn insert_unsized() {
+        let mut bf = BloomFilter::with_params(100, 2);
+
+        assert!(bf.insert("test1").unwrap());
+        assert!(bf.query("test1"));
+        assert!(!bf.query("test2"));
     }
 }

--- a/src/filters/cuckoofilter.rs
+++ b/src/filters/cuckoofilter.rs
@@ -136,7 +136,7 @@ pub struct CuckooFilterFull;
 #[derive(Clone)]
 pub struct CuckooFilter<T, R, B = BuildHasherDefault<DefaultHasher>>
 where
-    T: Hash,
+    T: Hash + ?Sized,
     R: Rng,
     B: BuildHasher + Clone + Eq,
 {
@@ -152,7 +152,7 @@ where
 
 impl<T, R> CuckooFilter<T, R>
 where
-    T: Hash,
+    T: Hash + ?Sized,
     R: Rng,
 {
     /// Create new CuckooFilter with:
@@ -191,7 +191,7 @@ where
 
 impl<T, R, B> CuckooFilter<T, R, B>
 where
-    T: Hash,
+    T: Hash + ?Sized,
     R: Rng,
     B: BuildHasher + Clone + Eq,
 {
@@ -377,7 +377,7 @@ where
 
     fn hash<U>(&self, obj: &U) -> usize
     where
-        U: Hash,
+        U: Hash + ?Sized,
     {
         let mut hasher = self.buildhasher.build_hasher();
         hasher.write_usize(1); // IV
@@ -467,7 +467,7 @@ where
 
 impl<T, R, B> Filter<T> for CuckooFilter<T, R, B>
 where
-    T: Hash,
+    T: Hash + ?Sized,
     R: Rng,
     B: BuildHasher + Clone + Eq,
 {
@@ -565,7 +565,7 @@ where
 
 impl<T, R, B> fmt::Debug for CuckooFilter<T, R, B>
 where
-    T: Hash,
+    T: Hash + ?Sized,
     R: Rng,
     B: BuildHasher + Clone + Eq,
 {
@@ -910,5 +910,15 @@ mod tests {
         assert!(cf2.union(&cf1).is_err());
         assert_eq!(cf2.len(), n_cf2 as usize);
         assert!(!cf2.query(&1));
+    }
+
+    #[test]
+    fn insert_unsized() {
+        let mut cf = CuckooFilter::with_params(ChaChaRng::from_seed([0; 32]), 2, 16, 8);
+        assert!(cf.insert("test1").unwrap());
+        assert!(!cf.is_empty());
+        assert_eq!(cf.len(), 1);
+        assert!(cf.query("test1"));
+        assert!(!cf.query("test2"));
     }
 }

--- a/src/filters/mod.rs
+++ b/src/filters/mod.rs
@@ -15,7 +15,7 @@ use std::hash::Hash;
 /// This kind of lookup is also referred to as Approximate Membership Queries (AMQs).
 pub trait Filter<T>
 where
-    T: Hash,
+    T: Hash + ?Sized,
 {
     /// Error type that may occur during insertion.
     type InsertErr: Debug;

--- a/src/filters/quotientfilter.rs
+++ b/src/filters/quotientfilter.rs
@@ -241,7 +241,7 @@ impl ScanResult {
 #[derive(Clone, Debug)]
 pub struct QuotientFilter<T, B = BuildHasherDefault<DefaultHasher>>
 where
-    T: Hash,
+    T: Hash + ?Sized,
     B: BuildHasher + Clone + Eq,
 {
     is_occupied: FixedBitSet,
@@ -256,7 +256,7 @@ where
 
 impl<T> QuotientFilter<T>
 where
-    T: Hash,
+    T: Hash + ?Sized,
 {
     /// Create new quotient filter with:
     ///
@@ -274,7 +274,7 @@ where
 
 impl<T, B> QuotientFilter<T, B>
 where
-    T: Hash,
+    T: Hash + ?Sized,
     B: BuildHasher + Clone + Eq,
 {
     /// Create new quotient filter with:
@@ -509,7 +509,7 @@ where
 
 impl<T, B> Filter<T> for QuotientFilter<T, B>
 where
-    T: Hash,
+    T: Hash + ?Sized,
     B: BuildHasher + Clone + Eq,
 {
     type InsertErr = QuotientFilterFull;
@@ -818,5 +818,15 @@ mod tests {
         assert!(qf2.union(&qf1).is_err());
         assert_eq!(qf2.len(), n_qf2 as usize);
         assert!(!qf2.query(&1));
+    }
+
+    #[test]
+    fn insert_unsized() {
+        let mut qf = QuotientFilter::with_params(3, 16);
+        assert!(qf.insert("test1").unwrap());
+        assert!(!qf.is_empty());
+        assert_eq!(qf.len(), 1);
+        assert!(qf.query("test1"));
+        assert!(!qf.query("test2"));
     }
 }

--- a/src/hash_utils.rs
+++ b/src/hash_utils.rs
@@ -107,7 +107,7 @@ where
     /// used.
     pub fn iter_for<T>(&self, obj: &T) -> HashIter<B>
     where
-        T: Hash,
+        T: Hash + ?Sized,
     {
         let h1 = self.h_i(&obj, 0) % (self.m as u64);
         let h2 = self.h_i(&obj, 1) % (self.m as u64);
@@ -128,7 +128,7 @@ where
     /// Helper to calculate h_0 and h_1.
     fn h_i<T>(&self, obj: &T, i: usize) -> u64
     where
-        T: Hash,
+        T: Hash + ?Sized,
     {
         let mut hasher = self.buildhasher.build_hasher();
         hasher.write_usize(i);


### PR DESCRIPTION
Expand the type constraints on the filter implementations to allow `?Sized` types. This makes it easier to work with unsized types, such as `str`.

Because the filters only store hashes/fingerprints of `T`, there is no requirement for `T` to be sized.