### PR TITLE
fix: Correct n_blocks calculation in all_zero_intvector

### DIFF
--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -1,5 +1,4 @@
 #![allow(dead_code)]
-use std::mem;
 
 use succinct::IntVector;
 use succinct::storage::BlockType;


### PR DESCRIPTION
Fix the calculation logic error of block count in all_zero_intvector, the previous result was larger than expected.

In [CuckooFilter](https://github.com/crepererum-oss/pdatastructs.rs/blob/09270956a5cd79a180184b0bfcc31b35a07eec4a/src/filters/cuckoofilter.rs#L249), I can confirm the old code is wrong, the argument `len` is the number of fingerprint.
In QuotientFilter, I'm not familiar with it, @crepererum please check it.
